### PR TITLE
Add tests to mapIterators

### DIFF
--- a/mapIterators.js
+++ b/mapIterators.js
@@ -38,6 +38,14 @@ class VectorCollection {
   *yielder() {
     yield *this.buffer;
   }
+
+  entriesForOfLoop(callback) {
+    for (let item of this.buffer.entries()) callback(item);
+  }
+
+  valuesForOfLoop(callback) {
+    for (let item of this.buffer.values()) callback(item);
+  }
 }
 
 let nativeSum = 0;
@@ -45,6 +53,9 @@ let forLoop = 0;
 let forOfLoop = 0;
 let iterator = 0;
 let yielder = 0;
+let entriesForOfLoop = 0;
+let entriesForOfLoopKV = 0;
+let valuesForOfLoop = 0;
 let testCollection = new VectorCollection(10000);
 
 suite.add('map.forEach(cb)', function() {
@@ -71,6 +82,24 @@ suite.add('map.forEach(cb)', function() {
     yielder += v[1].x * v[1].x
   };
 })
+.add('entriesForOfLoop', function() {
+  entriesForOfLoop = 0;
+  testCollection.entriesForOfLoop(v => {
+    entriesForOfLoop += v[1].x * v[1].x
+  });
+})
+.add('entriesForOfLoopKV', function() {
+  entriesForOfLoopKV = 0;
+  testCollection.entriesForOfLoop(([k,v]) => {
+    entriesForOfLoopKV += v.x * v.x
+  });
+})
+.add('valuesForOfLoop', function() {
+  valuesForOfLoop = 0;
+  testCollection.valuesForOfLoop(v => {
+    valuesForOfLoop += v.x * v.x
+  });
+})
 .on('cycle', function(event) {
   console.log(String(event.target));
 })
@@ -79,7 +108,10 @@ suite.add('map.forEach(cb)', function() {
   console.log('')
   if ((forOfLoop !== nativeSum) || 
      (iterator !== nativeSum) ||
-     (yielder !== nativeSum)
+     (yielder !== nativeSum) ||
+     (entriesForOfLoop !== nativeSum) ||
+     (entriesForOfLoopKV !== nativeSum) ||
+     (valuesForOfLoop !== nativeSum)
      ) throw new Error('Invalid test. Sums do not match');
 })
 .run({ 'async': true });


### PR DESCRIPTION
I added some tests to mapIterators and the result in my enviroment was:
```
map.forEach(cb) x 3,931 ops/sec ±3.24% (86 runs sampled)
for (let item of map) cb(item) x 4,256 ops/sec ±1.02% (88 runs sampled)
iterator x 4,279 ops/sec ±1.89% (86 runs sampled)
yield * x 1,389 ops/sec ±0.84% (91 runs sampled)
entriesForOfLoop x 4,527 ops/sec ±0.64% (89 runs sampled)
entriesForOfLoopKV x 2,730 ops/sec ±2.92% (83 runs sampled)
valuesForOfLoop x 6,085 ops/sec ±1.84% (90 runs sampled)
Fastest is valuesForOfLoop
```

Using `for (let item of map.entries())` seems to be slightly faster than `for (let item of map)`, and using map.values() is definitely the fastest - of course it is useful if you only need the values.

Using array destructuring in the callback (`([k,v]) =>`), which is pretty used these days, caused a huge drop of performance.